### PR TITLE
chore: Updating faraday to version 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@
 # THE SOFTWARE.
 #--------------------------------------------------------------------------
 source "https://rubygems.org" do
-  gem "faraday",             "~> 1.0", :require => false
+  gem "faraday",             "~> 2.0", :require => false
   gem "faraday_middleware",  "~> 1.0.0.rc1", :require => false
   gem "net-http-persistent", "~> 4.0", :require => false
   gem "nokogiri",          "~> 1", ">= 1.10.8", :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,8 @@
 #--------------------------------------------------------------------------
 source "https://rubygems.org" do
   gem "faraday",             "~> 2.0", :require => false
-  gem "faraday_middleware",  "~> 1.0.0.rc1", :require => false
+  gem "faraday-follow_redirects", "~> 0.3.0", :require => false
+  gem "faraday-net_http_persistent", "~> 2.0", :require => false
   gem "net-http-persistent", "~> 4.0", :require => false
   gem "nokogiri",          "~> 1", ">= 1.10.8", :require => false
   gem "adal",                "~> 1.0", :require => false

--- a/common/azure-storage-common.gemspec
+++ b/common/azure-storage-common.gemspec
@@ -42,7 +42,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.3.0"
 
   s.add_runtime_dependency('faraday',                 '~> 2.0')
-  s.add_runtime_dependency('faraday_middleware',      "~> 1.0", ">= 1.0.0.rc1")
+  s.add_runtime_dependency('faraday-follow_redirects','~> 0.3.0')
+  s.add_runtime_dependency('faraday-net_http_persistent', '~> 2.0')
   s.add_runtime_dependency("net-http-persistent",     '~> 4.0')
   s.add_runtime_dependency("nokogiri",                "~> 1", ">= 1.10.8")
   s.add_development_dependency("dotenv",              "~> 2.0")

--- a/common/azure-storage-common.gemspec
+++ b/common/azure-storage-common.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.3.0"
 
-  s.add_runtime_dependency('faraday',                 '~> 1.0')
+  s.add_runtime_dependency('faraday',                 '~> 2.0')
   s.add_runtime_dependency('faraday_middleware',      "~> 1.0", ">= 1.0.0.rc1")
   s.add_runtime_dependency("net-http-persistent",     '~> 4.0')
   s.add_runtime_dependency("nokogiri",                "~> 1", ">= 1.10.8")

--- a/common/lib/azure/core.rb
+++ b/common/lib/azure/core.rb
@@ -16,7 +16,8 @@
 require 'rubygems'
 require 'nokogiri'
 require 'faraday'
-require 'faraday_middleware'
+require 'faraday/follow_redirects'
+require 'faraday/net_http_persistent'
 
 module Azure
   module Core

--- a/common/lib/azure/storage/common/autoload.rb
+++ b/common/lib/azure/storage/common/autoload.rb
@@ -30,7 +30,7 @@ require "base64"
 require "openssl"
 require "uri"
 require "faraday"
-require "faraday_middleware"
+require 'faraday/follow_redirects'
 
 require "azure/storage/common/core/autoload"
 require "azure/storage/common/default"

--- a/common/lib/azure/storage/common/core/http_client.rb
+++ b/common/lib/azure/storage/common/core/http_client.rb
@@ -71,7 +71,7 @@ module Azure::Storage::Common::Core
                           URI::parse(ENV["HTTPS_PROXY"])
                         end || nil
         Faraday.new(uri, ssl: ssl_options, proxy: proxy_options) do |conn|
-          conn.use FaradayMiddleware::FollowRedirects
+          conn.response :follow_redirects #use Faraday::FollowRedirects::Middleware
           conn.adapter :net_http_persistent, pool_size: 5 do |http|
             # yields Net::HTTP::Persistent
             http.idle_timeout = 100


### PR DESCRIPTION
ref: https://linear.app/chatwoot/issue/CW-1356/slack-gem-is-1-year-old